### PR TITLE
chore(release): :rocket: 0.1.0 [skip ci]

### DIFF
--- a/.docker/docker.version
+++ b/.docker/docker.version
@@ -1,1 +1,1 @@
-IMAGE_VERSION="0.0.0"                    # The version of the project
+IMAGE_VERSION="0.1.0"                    # The version of the project

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,11 @@
 <!--next-version-placeholder-->
+
+## v0.1.0 (2024-10-12)
+
+### Feature
+
+* Initialize llama-factory-container repo with Hyperfast Docker Template ([`8d6bd36`](https://github.com/entelecheia/llama-factory-container/commit/8d6bd3689a9cd7ab08f2556313bd8b42faa51ebd))
+
+### Documentation
+
+* Update README.md with container information and usage instructions ([`e3eee10`](https://github.com/entelecheia/llama-factory-container/commit/e3eee10c9e3dc2b55674a2e3cc26dbce20b7ee50))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "llama-factory"
-version = "0.0.0"
+version = "0.1.0"
 description = "llama-factory-container is a comprehensive AI model training and deployment framework supporting various models, methods, and optimizations."
 authors = ["Young Joon Lee <entelecheia@hotmail.com>"]
 license = "MIT"


### PR DESCRIPTION
Automatically generated by python-semantic-release